### PR TITLE
Environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore generated environment
+/.ruby-env
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: ruby
+services: postgresql
 bundler_args: "--binstubs --jobs=3 --retry=3"
 before_install: gem install bundler -v 1.11.2
 cache: bundler
+env:
+  global:
+  - GRANTZILLA_SECRET_KEY_BASE=e7294b5390667f80f17ca101925f19697a151827cd2e7297d0f4f21eb1c7fad633f7d92a60c3d1c3e99ac07364f242670724a4a1cbc8f29d747f8a0919d68256
+  - GRANTZILLA_ENV_SETUP=1
+  - GRANTZILLA_DATABASE_USERNAME=postgres
+  - GRANTZILLA_DATABASE_PASSWORD=
+before_script:
+- psql -c 'create database grantzilla_test;' -U postgres
 script:
 - bundle exec rake
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2"
-gem "sqlite3"
+gem "pg"
 gem "sass-rails", "~> 5.0"
 gem "uglifier", ">= 1.3.0"
 gem "coffee-rails", "~> 4.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     parser (2.3.0.1)
       ast (~> 2.2)
+    pg (0.18.4)
     powerpack (0.1.1)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -123,7 +124,6 @@ GEM
     rainbow (2.0.0)
     rake (10.5.0)
     rdoc (4.2.1)
-      json (~> 1.4)
     ref (2.0.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -170,7 +170,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -203,13 +202,13 @@ DEPENDENCIES
   jquery-rails
   letter_opener
   mailgun_rails
+  pg
   rails (~> 4.2)
   rspec-rails (~> 3.4)
   rubocop (~> 0.36)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
-  sqlite3
   therubyracer
   turbolinks
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 [![Build Status](https://travis-ci.org/on-site/Grantzilla.svg?branch=master)](https://travis-ci.org/on-site/Grantzilla)
 
+## Development Environment
+
+Run `rake setup` to prepare the necessary environment variables to begin
+development. After that, you will need to run `rvm use .` to load the
+environment variables generated in `.ruby-env`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,10 @@ module Grantzilla
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.before_initialize do
+      require "environment_setup"
+      EnvironmentSetup.check_setup
+    end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,18 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: 5
-  timeout: 5000
+  username: <%= ENV['GRANTZILLA_DATABASE_USERNAME'] %>
+  password: <%= ENV['GRANTZILLA_DATABASE_PASSWORD'] %>
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: grantzilla_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: grantzilla_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: grantzilla_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,8 +63,8 @@ Rails.application.configure do
   # Send email using mailgun API
   config.action_mailer.delivery_method = :mailgun
   config.action_mailer.mailgun_settings = {
-    api_key: ENV["MAILGUN_API_KEY"],
-    domain: ENV["MAILGUN_DOMAIN"]
+    api_key: ENV["GRANTZILLA_MAILGUN_API_KEY"],
+    domain: ENV["GRANTZILLA_MAILGUN_DOMAIN"]
   }
   RestClient.log = ::Rails.logger # mailgun_rails uses RestClient under the hood.
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,13 +10,16 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+# Do not keep secrets in the repository, generate them at setup and keep them in the environment.
+# See lib/environment_setup.rb
+default: &default
+  secret_key_base: <%= ENV["GRANTZILLA_SECRET_KEY_BASE"] %>
+
 development:
-  secret_key_base: a2947d74790051cc7beacb4f6244e44f3dcbe7e73fd46db70a6ae284b8128b903a4685282cbaa7c65b01a3f611b5baaed3c31299e84d10c03a404f9e0d78abcb
+  <<: *default
 
 test:
-  secret_key_base: e7294b5390667f80f17ca101925f19697a151827cd2e7297d0f4f21eb1c7fad633f7d92a60c3d1c3e99ac07364f242670724a4a1cbc8f29d747f8a0919d68256
+  <<: *default
 
-# Do not keep production secrets in the repository,
-# instead read values from the environment.
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  <<: *default

--- a/lib/environment_setup.rb
+++ b/lib/environment_setup.rb
@@ -7,7 +7,6 @@ class EnvironmentSetup
   RED = "\e[31m".freeze
   GREEN = "\e[32m".freeze
   BOLD = "\e[1m".freeze
-  BOLD_OFF = "\e[22m".freeze
   CLEAR = "\e[0m".freeze
 
   attr_reader :changed
@@ -25,10 +24,10 @@ class EnvironmentSetup
 
   def self.check_setup
     unless EnvironmentSetup.setup?
-      abort "#{RED}#{BOLD}Your environment is not set up!\n" \
-            "Please run the following commands:#{BOLD_OFF}\n" \
-            "$ rake setup\n" \
-            "$ rvm use .#{CLEAR}"
+      abort "#{RED}#{BOLD}Your environment is not set up!#{CLEAR}\n" \
+            "#{RED}#{BOLD}Please run the following commands:#{CLEAR}\n" \
+            "#{RED}$ rake setup#{CLEAR}\n" \
+            "#{RED}$ rvm use .#{CLEAR}"
     end
   end
 

--- a/lib/environment_setup.rb
+++ b/lib/environment_setup.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+# rubocop:disable Rails/Output
+class EnvironmentSetup
+  # Increment this version if you change the setup such that everyone should re-run this
+  VERSION = 1
+  ENV_FILE = File.expand_path("../../.ruby-env", __FILE__).freeze
+  RED = "\e[31m".freeze
+  GREEN = "\e[32m".freeze
+  BOLD = "\e[1m".freeze
+  BOLD_OFF = "\e[22m".freeze
+  CLEAR = "\e[0m".freeze
+
+  attr_reader :changed
+  alias changed? changed
+
+  def self.setup
+    new.setup
+  end
+
+  def self.setup?
+    # This setup is not meant for production
+    return true if Rails.env.production?
+    ENV["GRANTZILLA_ENV_SETUP"] == VERSION.to_s
+  end
+
+  def self.check_setup
+    unless EnvironmentSetup.setup?
+      abort "#{RED}#{BOLD}Your environment is not set up!\n" \
+            "Please run the following commands:#{BOLD_OFF}\n" \
+            "$ rake setup\n" \
+            "$ rvm use .#{CLEAR}"
+    end
+  end
+
+  def setup
+    setup_secret_key_base
+    setup_postgres
+    update_env_setup
+
+    if changed?
+      puts "#{GREEN}Your environment is now setup!#{CLEAR}\n" \
+           "Please run the following:\n" \
+           "$ rvm use ."
+    else
+      puts "Your environemt is already setup!"
+    end
+  end
+
+  private
+
+  def setup_secret_key_base
+    update "GRANTZILLA_SECRET_KEY_BASE" do
+      puts "Generating secret key base"
+      require "securerandom"
+      SecureRandom.hex 64
+    end
+  end
+
+  def setup_postgres
+    update "GRANTZILLA_DATABASE_USERNAME", prompt: "What is your postgres username?"
+    update "GRANTZILLA_DATABASE_PASSWORD", prompt: "What is your postgres password?"
+  end
+
+  def update_env_setup
+    update("GRANTZILLA_ENV_SETUP") { VERSION }
+  end
+
+  def update(env_var, prompt: nil)
+    return if ENV[env_var].present?
+
+    if block_given?
+      save_env env_var, yield
+    else
+      print "#{prompt}\n> "
+      save_env env_var, STDIN.gets.strip
+    end
+
+    changed!
+  end
+
+  def save_env(env_var, value)
+    if File.exist? ENV_FILE
+      update_env(env_var, value)
+    else
+      File.write(ENV_FILE, "#{env_var}=#{value}\n")
+    end
+  end
+
+  def update_env(env_var, value)
+    contents = File.read ENV_FILE
+
+    if contents =~ /^#{Regexp.escape env_var}=/
+      contents.sub!(/^#{Regexp.escape env_var}=.*$/, "#{env_var}=#{value}")
+    else
+      contents << "#{env_var}=#{value}\n"
+    end
+
+    File.write(ENV_FILE, contents)
+  end
+
+  def changed!
+    @changed = true
+  end
+end
+# rubocop:enable Rails/Output

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -2,5 +2,5 @@ require "rubocop/rake_task"
 require "rspec/core/rake_task"
 
 RuboCop::RakeTask.new
-task spec: :rubocop
+task spec: [:check_setup, :rubocop]
 task default: :spec

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -1,0 +1,11 @@
+require File.expand_path("../../environment_setup", __FILE__)
+
+desc "Configure your environment for development"
+task :setup do
+  EnvironmentSetup.setup
+end
+
+desc "Check if your environment is setup for development"
+task :check_setup do
+  EnvironmentSetup.check_setup
+end


### PR DESCRIPTION
This contains @joedean's postgres commit.

I added Travis configuration of postgres.

The base idea of `rake setup` is that it uses a `.ruby-env` file to contain the configuration needed for development, and it is kept git ignored so it won't be accidentally committed. The `GRANTZILLA_ENV_SETUP` variable is a number that can be increased whenever the setup needs to change for everyone.... then everyone will see the error that they need to setup again, and can setup.
