### PR TITLE
Begin new grant view, add datepicker, add guards js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'devise-bootstrap-views'
 
 gem "jquery-rails"
 gem "turbolinks"
+gem "jquery-turbolinks"
 gem "jbuilder", "~> 2.0"
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 0.4.0", group: :doc

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "momentjs-rails", ">= 2.9.0"
 gem "newrelic_rpm"
 gem "bootstrap-sass", "~> 3.3.6"
 gem "bootstrap3-datetimepicker-rails", "~> 4.17.37"
+gem "bootstrap-guardsjs-rails", "~> 0.4"
 
 # paperclip with support for S3 storage with aws-sdk v2
 # has not been published yet but is on master as of 1/22/16.

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,10 @@ gem "turbolinks"
 gem "jbuilder", "~> 2.0"
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 0.4.0", group: :doc
+gem "momentjs-rails", ">= 2.9.0"
 gem "newrelic_rpm"
 gem "bootstrap-sass", "~> 3.3.6"
+gem "bootstrap3-datetimepicker-rails", "~> 4.17.37"
 
 # paperclip with support for S3 storage with aws-sdk v2
 # has not been published yet but is on master as of 1/22/16.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,9 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -255,6 +258,7 @@ DEPENDENCIES
   devise-bootstrap-views
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   letter_opener
   mailgun_rails
   momentjs-rails (>= 2.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
     bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-guardsjs-rails (0.4.0)
+      guardsjs-rails (>= 1.2.0)
+      railties (>= 3.0, < 5.0)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -97,6 +100,8 @@ GEM
     execjs (2.6.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    guardsjs-rails (1.5.1)
+      railties (>= 3.0, < 5.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -241,6 +246,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk
+  bootstrap-guardsjs-rails (~> 0.4)
   bootstrap-sass (~> 3.3.6)
   bootstrap3-datetimepicker-rails (~> 4.17.37)
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
+    bootstrap3-datetimepicker-rails (4.17.37)
+      momentjs-rails (>= 2.8.1)
     builder (3.2.2)
     byebug (8.2.1)
     climate_control (0.0.3)
@@ -123,6 +125,8 @@ GEM
     mimemagic (0.3.1)
     mini_portile2 (2.0.0)
     minitest (5.8.3)
+    momentjs-rails (2.11.0)
+      railties (>= 3.1)
     multi_json (1.11.2)
     netrc (0.11.0)
     newrelic_rpm (3.14.1.311)
@@ -238,6 +242,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk
   bootstrap-sass (~> 3.3.6)
+  bootstrap3-datetimepicker-rails (~> 4.17.37)
   byebug
   coffee-rails (~> 4.1.0)
   devise (~> 3.5)
@@ -246,6 +251,7 @@ DEPENDENCIES
   jquery-rails
   letter_opener
   mailgun_rails
+  momentjs-rails (>= 2.9.0)
   newrelic_rpm
   paperclip!
   pg

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,6 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require bootstrap-sprockets
+//= require moment
+//= require bootstrap-datetimepicker
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,8 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
-//= require bootstrap-sprockets
 //= require moment
+//= require bootstrap-sprockets
 //= require bootstrap-datetimepicker
+//= require bootstrap-guards
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery.turbolinks
 //= require jquery_ujs
 //= require turbolinks
 //= require moment

--- a/app/assets/javascripts/datetimepicker.coffee
+++ b/app/assets/javascripts/datetimepicker.coffee
@@ -1,0 +1,2 @@
+$ ->
+  $(".datepicker").datetimepicker(format: "MM/DD/YYYY")

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,5 +18,6 @@
 // We override bootstrap variables in a file a subdirectory
 // so that it's not pulled in twice with the @import "*" below
 @import "bootstrap";
+@import "bootstrap-datetimepicker";
 @import "bootstrap-overrides/bootstrap-overrides";
 @import "*";

--- a/app/assets/stylesheets/bootstrap-overrides/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides/bootstrap-overrides.scss
@@ -7,3 +7,7 @@
 body {
   padding-top: 70px;
 }
+
+.form-group {
+  position: relative;
+}

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -18,6 +18,7 @@ class GrantsController < ApplicationController
 
   def create
     @grant = Grant.new(grant_params)
+    @grant.application_date = Time.zone.today
 
     if @grant.save
       redirect_to @grant
@@ -46,6 +47,6 @@ class GrantsController < ApplicationController
   end
 
   def grant_params
-    params.require(:grant).permit(:application_date, :details)
+    params.require(:grant).permit(people_attributes: [:first_name, :last_name, :birth_date, :email])
   end
 end

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -15,6 +15,7 @@ class GrantsController < ApplicationController
   # GET /grants/new
   def new
     @grant = Grant.new
+    @grant.people.build
   end
 
   # GET /grants/1/edit

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -47,6 +47,6 @@ class GrantsController < ApplicationController
   end
 
   def grant_params
-    params.require(:grant).permit(people_attributes: [:first_name, :last_name, :birth_date, :email])
+    params.require(:grant).permit(people_attributes: [:id, :first_name, :last_name, :birth_date, :email])
   end
 end

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,5 +1,7 @@
 class Grant < ActiveRecord::Base
-  has_many :grant_reasons
-  has_many :reason_types, through: :grant_reasons
-  has_many :people
+  has_many :grant_reasons, autosave: true
+  has_many :reason_types, through: :grant_reasons, autosave: true
+  has_many :people, autosave: true
+
+  accepts_nested_attributes_for :people, :grant_reasons
 end

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -1,6 +1,6 @@
-<%= form_for(@grant) do |f| %>
+<%= form_for(@grant, data: { live_guarded: true }) do |f| %>
   <% if @grant.errors.any? %>
-    <div id="error_explanation">
+    <div class="alert alert-danger">
       <h2><%= pluralize(@grant.errors.count, "error") %> prohibited this grant from being saved:</h2>
 
       <ul>
@@ -11,15 +11,27 @@
     </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :application_date %><br>
-    <%= f.date_select :application_date %>
-  </div>
-  <div class="field">
-    <%= f.label :details %><br>
-    <%= f.text_field :details %>
-  </div>
-  <div class="actions">
-    <%= f.submit %>
-  </div>
+  <h2>Primary Applicant</h2>
+
+  <%= f.fields_for :person, @grant.people.first do |p| %>
+    <div class="form-group">
+      <%= p.label :first_name, "First Name" %> <span class="text-danger">*</span>
+      <%= p.text_field :first_name, class: "form-control", data: { guard: "required" } %>
+    </div>
+    <div class="form-group">
+      <%= p.label :last_name, "Last Name" %> <span class="text-danger">*</span>
+      <%= p.text_field :last_name, class: "form-control", data: { guard: "required" } %>
+    </div>
+    <div class="form-group">
+      <%= p.label :birth_date, "Birth Date" %> <span class="text-danger">*</span>
+      <%= p.text_field :birth_date, class: "form-control datepicker", placeholder: "mm/dd/yyyy", data: { guard: "required dateUS" } %>
+    </div>
+    <div class="form-group">
+      <%= p.label :email, "Email" %>
+      <%= p.text_field :email, class: "form-control", data: { guard: "email" } %>
+    </div>
+  <% end %>
+
+  <%= f.submit "Continue", class: "btn btn-primary" %>
+  <%= link_to 'Back', grants_path, class: "btn btn-link" %>
 <% end %>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -11,9 +11,12 @@
     </div>
   <% end %>
 
-  <h2>Primary Applicant</h2>
-
-  <%= f.fields_for :person, @grant.people.first do |p| %>
+  <%= f.fields_for :people, @grant.people do |p| %>
+    <% if p.object == @grant.people.first %>
+      <h2>Primary Applicant</h2>
+    <% else %>
+      <hr />
+    <% end %>
     <div class="form-group">
       <%= p.label :first_name, "First Name" %> <span class="text-danger">*</span>
       <%= p.text_field :first_name, class: "form-control", data: { guard: "required" } %>

--- a/app/views/grants/edit.html.erb
+++ b/app/views/grants/edit.html.erb
@@ -1,6 +1,1 @@
-<h1>Editing Grant</h1>
-
 <%= render 'form' %>
-
-<%= link_to 'Show', @grant %> |
-<%= link_to 'Back', grants_path %>

--- a/app/views/grants/new.html.erb
+++ b/app/views/grants/new.html.erb
@@ -1,5 +1,1 @@
-<h1>New Grant</h1>
-
 <%= render 'form' %>
-
-<%= link_to 'Back', grants_path %>

--- a/spec/views/grants/edit.html.erb_spec.rb
+++ b/spec/views/grants/edit.html.erb_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe "grants/edit", type: :view do
     render
 
     assert_select "form[action=?][method=?]", grant_path(@grant), "post" do
-      assert_select "input#grant_person_first_name[name=?]", "grant[person][first_name]"
-      assert_select "input#grant_person_last_name[name=?]", "grant[person][last_name]"
-      assert_select "input#grant_person_birth_date[name=?]", "grant[person][birth_date]"
-      assert_select "input#grant_person_email[name=?]", "grant[person][email]"
+      assert_select "input#grant_people_attributes_0_first_name[name=?]", "grant[people_attributes][0][first_name]"
+      assert_select "input#grant_people_attributes_0_last_name[name=?]", "grant[people_attributes][0][last_name]"
+      assert_select "input#grant_people_attributes_0_birth_date[name=?]", "grant[people_attributes][0][birth_date]"
+      assert_select "input#grant_people_attributes_0_email[name=?]", "grant[people_attributes][0][email]"
     end
   end
 end

--- a/spec/views/grants/edit.html.erb_spec.rb
+++ b/spec/views/grants/edit.html.erb_spec.rb
@@ -2,16 +2,19 @@ require "rails_helper"
 
 RSpec.describe "grants/edit", type: :view do
   before(:each) do
-    @grant = assign(:grant, Grant.create!(
-                              details: "MyString"
-    ))
+    @grant = Grant.create!
+    @grant.people.create!
+    assign(:grant, @grant)
   end
 
   it "renders the edit grant form" do
     render
 
     assert_select "form[action=?][method=?]", grant_path(@grant), "post" do
-      assert_select "input#grant_details[name=?]", "grant[details]"
+      assert_select "input#grant_person_first_name[name=?]", "grant[person][first_name]"
+      assert_select "input#grant_person_last_name[name=?]", "grant[person][last_name]"
+      assert_select "input#grant_person_birth_date[name=?]", "grant[person][birth_date]"
+      assert_select "input#grant_person_email[name=?]", "grant[person][email]"
     end
   end
 end

--- a/spec/views/grants/new.html.erb_spec.rb
+++ b/spec/views/grants/new.html.erb_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe "grants/new", type: :view do
     render
 
     assert_select "form[action=?][method=?]", grants_path, "post" do
-      assert_select "input#grant_person_first_name[name=?]", "grant[person][first_name]"
-      assert_select "input#grant_person_last_name[name=?]", "grant[person][last_name]"
-      assert_select "input#grant_person_birth_date[name=?]", "grant[person][birth_date]"
-      assert_select "input#grant_person_email[name=?]", "grant[person][email]"
+      assert_select "input#grant_people_attributes_0_first_name[name=?]", "grant[people_attributes][0][first_name]"
+      assert_select "input#grant_people_attributes_0_last_name[name=?]", "grant[people_attributes][0][last_name]"
+      assert_select "input#grant_people_attributes_0_birth_date[name=?]", "grant[people_attributes][0][birth_date]"
+      assert_select "input#grant_people_attributes_0_email[name=?]", "grant[people_attributes][0][email]"
     end
   end
 end

--- a/spec/views/grants/new.html.erb_spec.rb
+++ b/spec/views/grants/new.html.erb_spec.rb
@@ -2,16 +2,19 @@ require "rails_helper"
 
 RSpec.describe "grants/new", type: :view do
   before(:each) do
-    assign(:grant, Grant.new(
-                     details: "MyString"
-    ))
+    grant = Grant.new
+    grant.people.build
+    assign(:grant, grant)
   end
 
   it "renders new grant form" do
     render
 
     assert_select "form[action=?][method=?]", grants_path, "post" do
-      assert_select "input#grant_details[name=?]", "grant[details]"
+      assert_select "input#grant_person_first_name[name=?]", "grant[person][first_name]"
+      assert_select "input#grant_person_last_name[name=?]", "grant[person][last_name]"
+      assert_select "input#grant_person_birth_date[name=?]", "grant[person][birth_date]"
+      assert_select "input#grant_person_email[name=?]", "grant[person][email]"
     end
   end
 end


### PR DESCRIPTION
Beginnings of the view for creating a grant.  Also includes the ability to save the grant.

Adds the ability for you to add `.datepicker` to an input and automatically have it get picked up as a date type field with a date picker pop up.

Also adds in the [Guards JS library](http://guardsjs.com/) for super-easy client-side validations.
