### PR TITLE
Reorganized CSS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,14 +10,12 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require_tree .
- *= require_self
- *= require devise_bootstrap_views
  */
 @import "bootstrap-sprockets";
 // We override bootstrap variables in a file a subdirectory
 // so that it's not pulled in twice with the @import "*" below
+@import "bootstrap-overrides/bootstrap-overrides";
 @import "bootstrap";
 @import "bootstrap-datetimepicker";
-@import "bootstrap-overrides/bootstrap-overrides";
+@import "devise_bootstrap_views";
 @import "*";

--- a/app/assets/stylesheets/bootstrap-overrides/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides/bootstrap-overrides.scss
@@ -3,18 +3,3 @@
  * Variables that can be overridden can be found at:
  * https://github.com/twbs/bootstrap-sass/blob/v3.3.6/assets/stylesheets/bootstrap/_variables.scss
  */
-
-body {
-  padding-top: 70px;
-}
-
-.form-group {
-  position: relative;
-}
-
-.tab-filters {
-  background: #eee;
-  border: 0px;
-  border-radius: 0px;
-  padding: 12px 8px;
-}

--- a/app/assets/stylesheets/grants.scss
+++ b/app/assets/stylesheets/grants.scss
@@ -1,3 +1,10 @@
 // Place all the styles related to the grants controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.tab-filters {
+  background: #eee;
+  border: 0px;
+  border-radius: 0px;
+  padding: 12px 8px;
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,0 +1,11 @@
+/*!
+ * This file contains CSS that applies to the application layout, not to any particular controller.
+ */
+
+body {
+  padding-top: 70px;
+}
+
+.form-group {
+  position: relative;
+}

--- a/app/assets/stylesheets/temp.scss
+++ b/app/assets/stylesheets/temp.scss
@@ -1,4 +1,0 @@
-/*
- * This file is a placeholder so that the require "*" line in application.scss doesn't fail.
- * As soon as another file is added to this directory, this file can be deleted.
- */


### PR DESCRIPTION
So that CSS specific to a controller is in a similarly-named (S)CSS file, and CSS general to the application layout is in layout.scss, leaving bootstrap-overrides to be specifically for overriding _variables_ defined by bootstrap.
