### PR TITLE
Procfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,4 +51,5 @@ end
 group :production do
   gem "aws-sdk"
   gem "mailgun_rails"
+  gem "sidekiq"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem "uglifier", ">= 1.3.0"
 # has not been published yet but is on master as of 1/22/16.
 gem "paperclip", github: "thoughtbot/paperclip"
 gem "rmagick"
+gem "puma"
+gem "rack-timeout"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,9 +162,11 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    puma (2.16.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack-timeout (0.3.2)
     rails (4.2.5)
       actionmailer (= 4.2.5)
       actionpack (= 4.2.5)
@@ -293,6 +295,8 @@ DEPENDENCIES
   paperclip!
   pg
   pry-rails
+  puma
+  rack-timeout
   rails (~> 4.2)
   react-rails
   rmagick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,7 @@ GEM
       execjs
       rails (>= 3.2)
       tilt
+    redis (3.2.2)
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
@@ -241,6 +242,10 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    sidekiq (4.0.2)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
     slop (3.6.0)
     spring (1.6.2)
     sprockets (3.5.2)
@@ -304,6 +309,7 @@ DEPENDENCIES
   rubocop (~> 0.36)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  sidekiq
   spring
   turbolinks
   uglifier (>= 1.3.0)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -q default -q mailers

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,34 @@ class User < ActiveRecord::Base
   def case_worker?
     role == 'case_worker'
   end
+
+  after_commit :send_pending_notifications
+
+  protected
+
+  def send_devise_notification(notification, *args)
+    # If the record is new or changed then delay the
+    # delivery until the after_commit callback otherwise
+    # send now because after_commit will not be called.
+    if new_record? || changed?
+      pending_notifications << [notification, args]
+    else
+      devise_mailer.send(notification, self, *args).deliver_later
+    end
+  end
+
+  def send_pending_notifications
+    pending_notifications.each do |notification, args|
+      devise_mailer.send(notification, self, *args).deliver_later
+    end
+
+    # Empty the pending notifications array because the
+    # after_commit hook can be called multiple times which
+    # could cause multiple emails to be sent.
+    pending_notifications.clear
+  end
+
+  def pending_notifications
+    @pending_notifications ||= []
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,4 +96,6 @@ Rails.application.configure do
     s3_permissions: :private,
     s3_protocol: ""
   }
+
+  config.active_job.queue_adapter = :sidekiq # Send emails in the background only in production
 end

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,0 +1,2 @@
+# Recommended in https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#timeout
+Rack::Timeout.timeout = 20 # seconds

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,17 @@
+# This file is copied from Heroku's recommendations at
+# https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
+# with some small changes
+
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(1)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
The Procfile has 2 instructions for heroku:
1) Use puma as the web server
2) Run a sidekiq worker in the background

The latter allows us to send emails, such as devise emails, asynchronously using `deliver_later`.
