### PR TITLE
Set end_year to current year for date_select

### DIFF
--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -31,7 +31,7 @@
     <div class="form-group">
       <%= p.label :birth_date, "Birth Date" %> <span class="text-danger">*</span>
       <div class="form-inline">
-        <%= p.date_select(:birth_date, { start_year: 1925, order: [:month, :day, :year] }, { class: "form-control", data: { guard: "required" } }) %>
+        <%= p.date_select(:birth_date, { start_year: 1925, end_year: Time.now.year, order: [:month, :day, :year] }, { class: "form-control", data: { guard: "required" } }) %>
       </div>
     </div>
 


### PR DESCRIPTION
Not only does it make sense to not let applicants be negative
years old, but this also ensures a consistant year range when
editing an existing applicant, rather than the Rails' default
of currently selected year + 5.

This is the final commit for for #78 
