### PR TITLE
Added ruby version to Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby "2.3.0"
+
 gem "better_errors"
 gem "binding_of_caller"
 


### PR DESCRIPTION
Heroku doesn't understand .ruby-version files and is building using MRI 2.0.0.
See https://devcenter.heroku.com/articles/ruby-support#ruby-versions
