### PR TITLE
Add pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "paperclip", github: "thoughtbot/paperclip"
 gem "rmagick"
 gem "puma"
 gem "rack-timeout"
+gem 'will_paginate', '~> 3.1.0'
+gem 'will_paginate-bootstrap'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,9 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
     wicked (1.2.1)
       railties (>= 3.0.7)
+    will_paginate (3.1.0)
+    will_paginate-bootstrap (1.0.1)
+      will_paginate (>= 3.0.3)
 
 PLATFORMS
   ruby
@@ -334,6 +337,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   wicked
+  will_paginate (~> 3.1.0)
+  will_paginate-bootstrap
 
 BUNDLED WITH
    1.11.2

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -17,6 +17,10 @@ body {
   position: relative;
 }
 
+.pagination {
+  margin: 0;
+}
+
 .navbar-brand {
   background: url(/images/hif_logo.png) 16px 4px no-repeat;
   background-size: 40px;
@@ -38,6 +42,7 @@ body {
     background-color: #ccd6cc;
   }
 }
+
 .table-filters {
   background-color: #dde7dd;
   display: block;
@@ -55,4 +60,16 @@ body {
   height: 16px;
   margin-bottom: -3px;
   width: 16px;
+}
+
+@media (max-width: $screen-sm-min - 1) {
+  .padding-top-xs-5 {
+    padding-top: 5px;
+  }
+}
+
+@media (min-width: $screen-sm-min) {
+  .text-right-sm {
+    text-align: right;
+  }
 }

--- a/app/controllers/agencies_controller.rb
+++ b/app/controllers/agencies_controller.rb
@@ -3,7 +3,7 @@ class AgenciesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @agencies = Agency.order(:name)
+    @agencies = Agency.order(:name).paginate(page: params[:page])
   end
 
   def show

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -96,6 +96,6 @@ class GrantsController < ApplicationController
   end
 
   def grant_index_params
-    params.permit(:agency_id, :search, :status, :user_id)
+    params.permit(:agency_id, :search, :status, :user_id, :page)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @users = User.all.order(:last_name)
+    @users = User.order(:last_name).paginate(page: params[:page]).all
   end
 
   def update

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,6 +1,8 @@
 class Agency < ActiveRecord::Base
   has_many :users
 
+  self.per_page = 20
+
   def self.find_hif
     find_by_name("HIF")
   end

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -30,6 +30,8 @@ class Grant < ActiveRecord::Base
 
   accepts_nested_attributes_for(*COMPONENTS, reject_if: :all_blank, allow_destroy: true)
 
+  self.per_page = 10
+
   scope :by_agency_id, -> (agency_id) { joins(:user).where(users: { agency_id: agency_id }) if agency_id.present? }
   scope :by_user_id, -> (user_id) { where(user_id: user_id) if user_id.present? }
   scope :search, (lambda do |search|
@@ -62,6 +64,7 @@ class Grant < ActiveRecord::Base
       .by_agency_id(options[:agency_id])
       .by_user_id(options[:user_id])
       .visible_for_user(current_user)
+      .paginate(page: options[:page])
       .order(id: :desc)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ActiveRecord::Base
 
   belongs_to :agency
 
+  self.per_page = 20
+
   def self.case_workers_by_agency(agency = nil)
     case_workers.where(agency: agency)
   end

--- a/app/views/agencies/index.html.erb
+++ b/app/views/agencies/index.html.erb
@@ -33,11 +33,16 @@
       <% end %>
     </tbody>
   </table>
-  <p>
-    <%= link_to new_agency_path, class: 'btn btn-primary btn-block-xs' do %>
-      <span class="glyphicon glyphicon-plus"></span> New Agency
-    <% end %>
-  </p>
+  <div class="row">
+    <div class="col-sm-6">
+      <%= link_to new_agency_path, class: 'btn btn-primary btn-block-xs' do %>
+        <span class="glyphicon glyphicon-plus"></span> New Agency
+      <% end %>
+    </div>
+    <div class="col-sm-6 text-right-sm padding-top-xs-5">
+      <%= will_paginate @agencies, renderer: BootstrapPagination::Rails %>
+    </div>
+  </div>
 <% else %>
   <div class="alert alert-warning">
     No agencies have been added yet.

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -65,9 +65,9 @@
 <% end %>
 <div class="row">
   <div class="col-sm-6">
-    <a href="<%= new_grant_path %>" class="btn btn-primary btn-block-xs">
+    <%= link_to new_grant_path, class: 'btn btn-primary btn-block-xs' do %>
       <span class="glyphicon glyphicon-plus"></span> New Application
-    </a>
+    <% end %>
   </div>
   <div class="col-sm-6 text-right-sm padding-top-xs-5">
     <%= will_paginate @grants, renderer: BootstrapPagination::Rails %>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -65,7 +65,7 @@
 <% end %>
 <div class="row">
   <div class="col-sm-6">
-    <a href="<%= new_grant_path %>" class="btn btn-primary">
+    <a href="<%= new_grant_path %>" class="btn btn-primary btn-block-xs">
       <span class="glyphicon glyphicon-plus"></span> New Application
     </a>
   </div>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -63,8 +63,13 @@
     No matching applications found.
   </div>
 <% end %>
-<p>
-  <a href="<%= new_grant_path %>" class="btn btn-primary">
-    <span class="glyphicon glyphicon-plus"></span> New Application
-  </a>
-</p>
+<div class="row">
+  <div class="col-sm-6">
+    <a href="<%= new_grant_path %>" class="btn btn-primary">
+      <span class="glyphicon glyphicon-plus"></span> New Application
+    </a>
+  </div>
+  <div class="col-sm-6 text-right-sm padding-top-xs-5">
+    <%= will_paginate @grants, renderer: BootstrapPagination::Rails %>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -39,11 +39,11 @@
       <% end %>
     </tbody>
   </table>
-  <p>
-    <%= link_to '<span class="glyphicon glyphicon-plus"></span> New User'.html_safe, "/", class: 'btn btn-primary btn-block-xs' %>
-  </p>
+  <div class="text-right-sm">
+    <%= will_paginate @users, renderer: BootstrapPagination::Rails %>
+  </div>
 <% else %>
   <div class="alert alert-warning">
-    No users have been added yet. <%= link_to '<span class="glyphicon glyphicon-plus"></span> New User'.html_safe, "/", class: 'btn btn-default' %>
+    No users have been added yet.
   </div>
 <% end %>


### PR DESCRIPTION
Adds pagination for grants, users, and agencies.  Uses 10 grants (since they're searchable), but 20 users and agencies per page.

This image was modified to use 5 grants per page since I don't have that much sample data...
![image](https://cloud.githubusercontent.com/assets/444693/15103458/422ba222-1571-11e6-8976-fc1188e5d6e4.png)
