### PR TITLE
Fix url for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/on-site/Grantzilla.svg?branch=master)](https://travis-ci.org/on-site/Grantzilla)
+[![Build Status](https://travis-ci.org/on-site/grantzilla.svg?branch=master)](https://travis-ci.org/on-site/grantzilla)
 
 ## Development Environment
 


### PR DESCRIPTION
Fix the build status icon.

Should look like this:
![image](https://cloud.githubusercontent.com/assets/444693/15450708/a2555aa2-1f68-11e6-8092-1ffadc23c0c7.png)

Not this:
![image](https://cloud.githubusercontent.com/assets/444693/15450710/b174bf8c-1f68-11e6-8535-00c545545a73.png)
