### PR TITLE
Send emails for comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,44 +2,39 @@ source "https://rubygems.org"
 
 ruby "2.3.0"
 
+gem "accountingjs-rails"
 gem "better_errors"
 gem "binding_of_caller"
-
-# bundle exec rake doc:rails generates the API under doc/api.
 gem "bootstrap-sass", "~> 3.3.6"
 gem "bootstrap3-datetimepicker-rails", "~> 4.17.37"
 gem "bootstrap-guardsjs-rails", "~> 0.4"
+gem "cocoon"
 gem "coffee-rails", "~> 4.1.0"
 gem "devise", "~> 3.5"
 gem "devise-bootstrap-views"
-gem "react-rails"
-
-gem 'accountingjs-rails'
 gem "jquery-rails"
-gem "turbolinks"
 gem "jquery-turbolinks"
 gem "jbuilder", "~> 2.0"
 gem "momentjs-rails", ">= 2.9.0"
 gem "newrelic_rpm"
-gem "pg"
-gem "rails", "~> 4.2"
-gem "sass-rails", "~> 5.0"
-gem "sdoc", "~> 0.4.0", group: :doc
-gem "select2-rails"
-gem "uglifier", ">= 1.3.0"
-
-gem "wicked"
-gem "simple_form"
-gem "cocoon"
-
 # paperclip with support for S3 storage with aws-sdk v2
 # has not been published yet but is on master as of 1/22/16.
 gem "paperclip", github: "thoughtbot/paperclip"
-gem "rmagick"
+gem "pg"
 gem "puma"
 gem "rack-timeout"
-gem 'will_paginate', '~> 3.1.0'
-gem 'will_paginate-bootstrap'
+gem "rails", "~> 4.2"
+gem "react-rails"
+gem "rmagick"
+gem "sass-rails", "~> 5.0"
+gem "sdoc", "~> 0.4.0", group: :doc
+gem "select2-rails"
+gem "simple_form"
+gem "turbolinks"
+gem "uglifier", ">= 1.3.0"
+gem "wicked"
+gem "will_paginate", "~> 3.1.0"
+gem "will_paginate-bootstrap"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,3 @@
+class ApplicationMailer < ActionMailer::Base
+  layout 'mailer'
+end

--- a/app/mailers/comments_mailer.rb
+++ b/app/mailers/comments_mailer.rb
@@ -1,0 +1,7 @@
+class CommentsMailer < ApplicationMailer
+  def comment_email(comment, user)
+    @comment = comment
+    mail to: user.email,
+         subject: "New comment on grant for #{@comment.grant.people.to_sentence}"
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,23 @@
 class Comment < ActiveRecord::Base
   belongs_to :grant
   belongs_to :user
+
+  after_create :notify_users
+  default_scope { order(id: :desc) }
+
+  def context
+    grant.comments.where("id < ?", id)
+  end
+
+  def notify_users
+    users =
+      if user.admin?
+        [grant.user]
+      else
+        User.admins
+      end
+    users.each do |user|
+      CommentsMailer.comment_email(self, user).deliver
+    end
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,7 +6,7 @@ class Comment < ActiveRecord::Base
   default_scope { order(id: :desc) }
 
   def context
-    grant.comments.where("id < ?", id)
+    @context ||= grant.comments.where("id < ?", id)
   end
 
   def notify_users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,10 @@ class User < ActiveRecord::Base
       .paginate(page: options[:page])
   end
 
+  def self.admins
+    where(role: :admin)
+  end
+
   def self.case_workers_by_agency(agency = nil)
     case_workers.where(agency: agency)
   end

--- a/app/views/application/_email_button.html.erb
+++ b/app/views/application/_email_button.html.erb
@@ -1,0 +1,35 @@
+<center>
+  <table width="100%">
+    <tr>
+      <td>
+        <table border="0" cellpadding="0" cellspacing="0">
+          <tr>
+            <td height="20" width="100%" style="font-size: 20px; line-height: 20px;">
+            </td>
+          </tr>
+        </table>
+        <table border="0" align="center" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+          <tbody>
+            <tr>
+              <td align="center">
+                <table border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+                  <tr>
+                    <td align="center" bgcolor="#3498DB" width="150">
+                      <%= link_to button_label, button_url, style: "padding: 10px; width: 150px; display: block; text-decoration: none; border: 1px solid #628b31; text-align: center; font-weight: bold; font-size: 15px; font-family: Calibri, sans-serif, 'Open Sans'; color: #ffffff; background: #628b31; line-height: 17px;", class: "button_link" %>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table border="0" cellpadding="0" cellspacing="0">
+          <tr>
+            <td height="20" width="100%" style="font-size: 20px; line-height: 20px;">
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</center>

--- a/app/views/comments_mailer/comment_email.html.erb
+++ b/app/views/comments_mailer/comment_email.html.erb
@@ -49,16 +49,17 @@
 
  <!-- END CENTERED BUTTON -->
 
-<p style="font-size: 17px; font-family: Calibri, sans-serif, 'Open Sans';">
-  <b>Previous Comments:</b>
-</p>
-
-<% @comment.context.each do |comment| %>
-  <hr>
-  <p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans'; color: #666666;">
-    by <%= comment.user %>
+<% if @comment.context.present? %>
+  <p style="font-size: 17px; font-family: Calibri, sans-serif, 'Open Sans';">
+    <b>Previous Comments:</b>
   </p>
-  <p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans'; color: #333333;">
-    <%= comment.body %>
-  </p>
+  <% @comment.context.each do |comment| %>
+    <hr>
+    <p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans'; color: #666666;">
+      by <%= comment.user %>
+    </p>
+    <p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans'; color: #333333;">
+      <%= comment.body %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/comments_mailer/comment_email.html.erb
+++ b/app/views/comments_mailer/comment_email.html.erb
@@ -11,43 +11,7 @@
   <%= @comment.body %>
 </p>
 
-<center>
-  <table width="100%">
-    <tr>
-      <td>
-        <table border="0" cellpadding="0" cellspacing="0">
-          <tr>
-            <td height="20" width="100%" style="font-size: 20px; line-height: 20px;">
-            </td>
-          </tr>
-        </table>
-        <table border="0" align="center" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
-          <tbody>
-            <tr>
-              <td align="center">
-                <table border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
-                  <tr>
-                    <td align="center" bgcolor="#3498DB" width="150">
-                      <%= link_to "View Grant", grant_url(@comment.grant), style: "padding: 10px; width: 150px; display: block; text-decoration: none; border: 1px solid #628b31; text-align: center; font-weight: bold; font-size: 15px; font-family: Calibri, sans-serif, 'Open Sans'; color: #ffffff; background: #628b31; line-height: 17px;", class: "button_link" %>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table border="0" cellpadding="0" cellspacing="0">
-          <tr>
-            <td height="20" width="100%" style="font-size: 20px; line-height: 20px;">
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-  </table>
-</center>
-
- <!-- END CENTERED BUTTON -->
+<%= render partial: "/application/email_button", locals: { button_label: "View Grant", button_url: grant_url(@comment.grant) } %>
 
 <% if @comment.context.present? %>
   <p style="font-size: 17px; font-family: Calibri, sans-serif, 'Open Sans';">

--- a/app/views/comments_mailer/comment_email.html.erb
+++ b/app/views/comments_mailer/comment_email.html.erb
@@ -1,0 +1,64 @@
+<p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans'; color: #333333;">
+  There has been a new comment added to the grant application for
+  <%= @comment.grant.people.to_sentence %>.
+</p>
+
+<p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans';">
+  <b><%= @comment.user %> says:</b>
+</p>
+
+<p style="font-size: 17px; font-family: Calibri, sans-serif, 'Open Sans';">
+  <%= @comment.body %>
+</p>
+
+<center>
+ 	<table width="100%">
+    <tr>
+      <td>
+ 				<table border="0" cellpadding="0" cellspacing="0">
+          <tr>
+            <td height="20" width="100%" style="font-size: 20px; line-height: 20px;">
+ 						</td>
+ 					</tr>
+        </table>
+        <table border="0" align="center" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+          <tbody>
+            <tr>
+              <td align="center">
+ 							  <table border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+                  <tr>
+                    <td align="center" bgcolor="#3498DB" width="150">
+                      <%= link_to "View Grant", grant_url(@comment.grant), style: "padding: 10px; width: 150px; display: block; text-decoration: none; border: 1px solid #628b31; text-align: center; font-weight: bold; font-size: 15px; font-family: Calibri, sans-serif, 'Open Sans'; color: #ffffff; background: #628b31; line-height: 17px;", class: "button_link" %>
+ 									  </td>
+ 								  </tr>
+                </table>
+              </td>
+ 				    </tr>
+          </tbody>
+        </table>
+        <table border="0" cellpadding="0" cellspacing="0">
+          <tr>
+            <td height="20" width="100%" style="font-size: 20px; line-height: 20px;">
+ 						</td>
+ 				  </tr>
+        </table>
+      </td>
+ 		</tr>
+  </table>
+</center>
+
+ <!-- END CENTERED BUTTON -->
+
+<p style="font-size: 17px; font-family: Calibri, sans-serif, 'Open Sans';">
+  <b>Previous Comments:</b>
+</p>
+
+<% @comment.context.each do |comment| %>
+  <hr>
+  <p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans'; color: #666666;">
+    by <%= comment.user %>
+  </p>
+  <p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans'; color: #333333;">
+    <%= comment.body %>
+  </p>
+<% end %>

--- a/app/views/comments_mailer/comment_email.html.erb
+++ b/app/views/comments_mailer/comment_email.html.erb
@@ -12,38 +12,38 @@
 </p>
 
 <center>
- 	<table width="100%">
+  <table width="100%">
     <tr>
       <td>
- 				<table border="0" cellpadding="0" cellspacing="0">
+        <table border="0" cellpadding="0" cellspacing="0">
           <tr>
             <td height="20" width="100%" style="font-size: 20px; line-height: 20px;">
- 						</td>
- 					</tr>
+            </td>
+          </tr>
         </table>
         <table border="0" align="center" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
           <tbody>
             <tr>
               <td align="center">
- 							  <table border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+                <table border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
                   <tr>
                     <td align="center" bgcolor="#3498DB" width="150">
                       <%= link_to "View Grant", grant_url(@comment.grant), style: "padding: 10px; width: 150px; display: block; text-decoration: none; border: 1px solid #628b31; text-align: center; font-weight: bold; font-size: 15px; font-family: Calibri, sans-serif, 'Open Sans'; color: #ffffff; background: #628b31; line-height: 17px;", class: "button_link" %>
- 									  </td>
- 								  </tr>
+                    </td>
+                  </tr>
                 </table>
               </td>
- 				    </tr>
+            </tr>
           </tbody>
         </table>
         <table border="0" cellpadding="0" cellspacing="0">
           <tr>
             <td height="20" width="100%" style="font-size: 20px; line-height: 20px;">
- 						</td>
- 				  </tr>
+            </td>
+          </tr>
         </table>
       </td>
- 		</tr>
+    </tr>
   </table>
 </center>
 

--- a/app/views/comments_mailer/comment_email.text.erb
+++ b/app/views/comments_mailer/comment_email.text.erb
@@ -7,9 +7,11 @@ There has been a new comment added to the grant application for
 To view this grant, please visit the following URL:
 <%= grant_url(@comment.grant) %>
 
+<% if @comment.context.present? %>
 Previous comments:
 <% @comment.context.each do |comment| %>
 
 From <%= comment.user %>
 <%= comment.body %>
+<% end %>
 <% end %>

--- a/app/views/comments_mailer/comment_email.text.erb
+++ b/app/views/comments_mailer/comment_email.text.erb
@@ -1,0 +1,15 @@
+There has been a new comment added to the grant application for
+<%= @comment.grant.people.to_sentence %>.
+
+<%= @comment.user %> says:
+<%= @comment.body %>
+
+To view this grant, please visit the following URL:
+<%= grant_url(@comment.grant) %>
+
+Previous comments:
+<% @comment.context.each do |comment| %>
+
+From <%= comment.user %>
+<%= comment.body %>
+<% end %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title></title>
+    <style type="text/css"></style>
+  </head>
+  <body>
+    <%= yield %>
+    <p style="font-size: 12px; font-family: Calibri, sans-serif, 'Open Sans';">
+      --<br>
+      Please do not reply to this email.  Instead, follow the links
+      provided to respond.
+    </p>
+  </body>
+</html>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,0 +1,4 @@
+<%= yield %>
+--
+Please do not reply to this email.  Instead, follow the links
+provided to respond.

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,6 +7,12 @@ FactoryGirl.define do
     end
   end
 
+  factory :comment do
+    body "This is a test."
+    association :grant
+    association :user
+  end
+
   factory :grant do
     application_date { Time.zone.now }
     status factory: :grant_status

--- a/spec/mailers/comments_mailer_spec.rb
+++ b/spec/mailers/comments_mailer_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe CommentsMailer, type: :mailer do
+  describe '#comment_mail' do
+    let(:admin) { create(:user, :admin) }
+    let(:case_worker) { create(:user, :case_worker) }
+    let(:comment) { grant.comments.create(body: "This is a test.", user: case_worker) }
+    let(:grant) { create(:grant, user: case_worker) }
+    let(:mail) { CommentsMailer.comment_email(comment, admin) }
+    let(:text_source) { mail.body.parts.first.body.raw_source.to_s }
+    let(:html_source) { mail.body.parts.last.body.raw_source.to_s }
+
+    before do
+      allow_any_instance_of(Comment).to receive(:notify_users).and_return(true)
+      grant.people.build(first_name: "Fred", last_name: "Flintstone")
+    end
+
+    it "renders the subject" do
+      expect(mail.subject).to eql("New comment on grant for Fred Flintstone")
+    end
+
+    it "renders the receiver email" do
+      expect(mail.to).to eq([admin.email])
+    end
+
+    it "includes both html and text parts" do
+      expect(mail.body.parts.size).to eq(2)
+    end
+
+    it "includes the comment" do
+      expect(text_source).to include(comment.body)
+      expect(html_source).to include(comment.body)
+    end
+
+    context "when there are no previous comments" do
+      it "shouldn't include a section for previous comments" do
+        expect(text_source).to_not include("Previous")
+        expect(html_source).to_not include("Previous")
+      end
+    end
+
+    context "when there are previous comments" do
+      let!(:old_comment) { grant.comments.create(body: "Entered before", user: admin) }
+      it "should include a section for previous comments" do
+        expect(text_source).to include("Previous")
+        expect(text_source).to include(old_comment.body)
+        expect(html_source).to include("Previous")
+        expect(html_source).to include(old_comment.body)
+      end
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Comment, type: :model do
   let(:admin) { create(:user, :admin) }
   let(:grant) { create(:grant, user: case_worker) }
   let(:comments_mail) { double("comment_mail", deliver: true) }
+
   describe "#create" do
     context "when the comment is created by the admin" do
       it "sends an email to the case worker" do
@@ -19,6 +20,28 @@ RSpec.describe Comment, type: :model do
       it "sends an email to the admin" do
         expect(CommentsMailer).to receive(:comment_email).with(anything, admin).and_return(comments_mail)
         grant.comments.create(user: case_worker, body: "Hello World")
+      end
+    end
+  end
+
+  describe "#context" do
+    let(:comment) { grant.comments.create(user: admin, body: "Work work work work work.") }
+    let(:context) { comment.context }
+    before do
+      allow(CommentsMailer).to receive(:comment_email).with(anything, anything).and_return(comments_mail)
+    end
+    context "when this is the only comment" do
+      it "returns an empty list" do
+        expect(context.size).to eq(0)
+      end
+    end
+    context "when there are other comments" do
+      let!(:comment1) { grant.comments.create(user: admin, body: "Hello?") }
+      let!(:comment2) { grant.comments.create(user: case_worker, body: "How are you?") }
+      it "returns only the other comments in reverse order" do
+        expect(context.size).to eq(2)
+        expect(context[0]).to eq(comment2)
+        expect(context[1]).to eq(comment1)
       end
     end
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Comment, type: :model do
+  let(:case_worker) { create(:user, :case_worker) }
+  let(:admin) { create(:user, :admin) }
+  let(:grant) { create(:grant, user: case_worker) }
+  let(:comments_mail) { double("comment_mail", deliver: true) }
+  describe "#create" do
+    context "when the comment is created by the admin" do
+      it "sends an email to the case worker" do
+        expect(CommentsMailer).to receive(:comment_email).with(anything, case_worker).and_return(comments_mail)
+        grant.comments.create(user: admin, body: "Hello World")
+      end
+    end
+    context "when the comment is created by the case worker" do
+      before do
+        admin
+      end
+      it "sends an email to the admin" do
+        expect(CommentsMailer).to receive(:comment_email).with(anything, admin).and_return(comments_mail)
+        grant.comments.create(user: case_worker, body: "Hello World")
+      end
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  let(:case_worker) { create(:user, :case_worker) }
   let(:admin) { create(:user, :admin) }
-  let(:grant) { create(:grant, user: case_worker) }
+  let(:case_worker) { create(:user, :case_worker) }
   let(:comments_mail) { double("comment_mail", deliver: true) }
+  let(:grant) { create(:grant, user: case_worker) }
 
   describe "#create" do
     context "when the comment is created by the admin" do


### PR DESCRIPTION
This pull request makes it so that we'll send emails when users make comments on grants.  The emails are exchanged between the case worker and any admin users on the platform.

![image](https://cloud.githubusercontent.com/assets/444693/15473346/26882388-20c5-11e6-8ccc-aa638d0d9d60.png)

![image](https://cloud.githubusercontent.com/assets/444693/15473365/35eef702-20c5-11e6-8663-a7e0e75acee9.png)
