### PR TITLE
#256 Rename document uploads to supportive documentation

### DIFF
--- a/app/views/forms/uploads.html.erb
+++ b/app/views/forms/uploads.html.erb
@@ -2,16 +2,29 @@
 
 <div class="row">
   <div class="col-md-8 col-sm-7">
-    <%= form_for(@upload, multipart: true) do |f| %>
-      <%= hidden_field(:upload, :user_id) %>
-      <%= hidden_field(:upload, :user_type) %>
-      <div class="field">
-        <%= f.file_field :file %>
+    <%= form_for(@upload, html: { class: 'new-upload form-horizontal', multipart: true }) do |f| %>
+      <div class="row">
+        <div class="col-xs-12">
           <h2>Supportive Documentation</h2>
+          <hr />
+        </div>
       </div>
-      <div class="actions">
-        <%= f.submit 'Upload Document' %>
-        <%= link_to 'Nevermind', class: 'button' %>
+      <div class="row">
+        <div class="form-group">
+          <label class="col-sm-3 control-label" style="padding-top: 0;">
+            Upload a file
+          </label>
+          <div class="col-sm-9">
+            <%= hidden_field(:upload, :user_id) %>
+            <%= hidden_field(:upload, :user_type) %>
+            <%= f.file_field :file %>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-offset-3 col-sm-9">
+            <%= f.submit 'Upload Document', class: 'btn btn-primary' %>
+          </div>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/forms/uploads.html.erb
+++ b/app/views/forms/uploads.html.erb
@@ -2,43 +2,39 @@
 
 <div class="row">
   <div class="col-md-8 col-sm-7">
+    <h2>Supportive Documentation</h2>
+    <hr />
+    <p>
+      The following supportive documentation is needed for every application:
+    </p>
+    <ul>
+      <li>
+        Three‐month budget that demonstrates cash crisis and sustainability in future
+        months
+      </li>
+      <li>
+        W‐9 from landlord
+      </li>
+      <li>
+        Relevant pages of lease (pages that show name of lessees, rental amount,
+        security deposit amount, rental dates, and signatures of lessees and payee). If
+        a lease has not been signed, an Acknowledgement to Rent can be submitted in lieu
+        of lease
+      </li>
+      <li>
+        Verification of owed costs (3‐Day Notice or other written verification of
+        exactly what lessee owes)
+      </li>
+      <li>
+        Verification of income for every adult (pay stubs, letter verifying employment,
+        benefits award letter, etc)
+      </li>
+      <li>
+        Verification of crisis (car repair bill, copy of no‐fault notice to vacate,
+        verification of illness)
+      </li>
+    </ul>
     <%= form_for(@upload, html: { class: 'new-upload form-horizontal', multipart: true }) do |f| %>
-      <div class="col-xs-12">
-        <h2>Supportive Documentation</h2>
-        <hr />
-      </div>
-      <div class="col-xs-12">
-        <p>
-          The following supportive documentation is needed for every application:
-        </p>
-        <ul>
-          <li>
-            Three‐month budget that demonstrates cash crisis and sustainability in future
-            months
-          </li>
-          <li>
-            W‐9 from landlord
-          </li>
-          <li>
-            Relevant pages of lease (pages that show name of lessees, rental amount,
-            security deposit amount, rental dates, and signatures of lessees and payee). If
-            a lease has not been signed, an Acknowledgement to Rent can be submitted in lieu
-            of lease
-          </li>
-          <li>
-            Verification of owed costs (3‐Day Notice or other written verification of
-            exactly what lessee owes)
-          </li>
-          <li>
-            Verification of income for every adult (pay stubs, letter verifying employment,
-            benefits award letter, etc)
-          </li>
-          <li>
-            Verification of crisis (car repair bill, copy of no‐fault notice to vacate,
-            verification of illness)
-          </li>
-        </ul>
-      </div>
       <div class="form-group">
         <label class="col-sm-3 control-label" style="padding-top: 0;">
           Upload a file

--- a/app/views/forms/uploads.html.erb
+++ b/app/views/forms/uploads.html.erb
@@ -2,12 +2,12 @@
 
 <div class="row">
   <div class="col-md-8 col-sm-7">
-    <h2>Upload Grant Documents</h2>
     <%= form_for(@upload, multipart: true) do |f| %>
       <%= hidden_field(:upload, :user_id) %>
       <%= hidden_field(:upload, :user_type) %>
       <div class="field">
         <%= f.file_field :file %>
+          <h2>Supportive Documentation</h2>
       </div>
       <div class="actions">
         <%= f.submit 'Upload Document' %>

--- a/app/views/forms/uploads.html.erb
+++ b/app/views/forms/uploads.html.erb
@@ -3,27 +3,55 @@
 <div class="row">
   <div class="col-md-8 col-sm-7">
     <%= form_for(@upload, html: { class: 'new-upload form-horizontal', multipart: true }) do |f| %>
-      <div class="row">
-        <div class="col-xs-12">
-          <h2>Supportive Documentation</h2>
-          <hr />
+      <div class="col-xs-12">
+        <h2>Supportive Documentation</h2>
+        <hr />
+      </div>
+      <div class="col-xs-12">
+        <p>
+          The following supportive documentation is needed for every application:
+        </p>
+        <ul>
+          <li>
+            Three‐month budget that demonstrates cash crisis and sustainability in future
+            months
+          </li>
+          <li>
+            W‐9 from landlord
+          </li>
+          <li>
+            Relevant pages of lease (pages that show name of lessees, rental amount,
+            security deposit amount, rental dates, and signatures of lessees and payee). If
+            a lease has not been signed, an Acknowledgement to Rent can be submitted in lieu
+            of lease
+          </li>
+          <li>
+            Verification of owed costs (3‐Day Notice or other written verification of
+            exactly what lessee owes)
+          </li>
+          <li>
+            Verification of income for every adult (pay stubs, letter verifying employment,
+            benefits award letter, etc)
+          </li>
+          <li>
+            Verification of crisis (car repair bill, copy of no‐fault notice to vacate,
+            verification of illness)
+          </li>
+        </ul>
+      </div>
+      <div class="form-group">
+        <label class="col-sm-3 control-label" style="padding-top: 0;">
+          Upload a file
+        </label>
+        <div class="col-sm-9">
+          <%= hidden_field(:upload, :user_id) %>
+          <%= hidden_field(:upload, :user_type) %>
+          <%= f.file_field :file %>
         </div>
       </div>
-      <div class="row">
-        <div class="form-group">
-          <label class="col-sm-3 control-label" style="padding-top: 0;">
-            Upload a file
-          </label>
-          <div class="col-sm-9">
-            <%= hidden_field(:upload, :user_id) %>
-            <%= hidden_field(:upload, :user_type) %>
-            <%= f.file_field :file %>
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="col-sm-offset-3 col-sm-9">
-            <%= f.submit 'Upload Document', class: 'btn btn-primary' %>
-          </div>
+      <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-9">
+          <%= f.submit 'Upload Document', class: 'btn btn-primary' %>
         </div>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,4 +24,4 @@ en:
   overview: Crisis & Grant Request
   properties: Property & Payee
   employment: Income Sources
-  uploads: Document Uploads
+  uploads: Supportive Documentation


### PR DESCRIPTION
For #256 

Also did some styling to match the other wizard pages.
- [x] Rename 'Uploads' page of wizard
- [x] Add required document list

<img width="1158" alt="screen shot 2016-06-12 at 11 07 29 am" src="https://cloud.githubusercontent.com/assets/1816102/15992956/00dac842-308e-11e6-9bd2-d1c42d84ef26.png">
