### PR TITLE
Remove jquery-turbolinks and use turbolinks events directly.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "coffee-rails", "~> 4.2"
 gem "devise", "~> 4.2"
 gem "devise-bootstrap-views"
 gem "jquery-rails"
-gem "jquery-turbolinks"
 gem "jbuilder", "~> 2.5"
 gem "momentjs-rails", ">= 2.9.0"
 # paperclip with support for S3 storage with aws-sdk v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,9 +130,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-turbolinks (2.1.0)
-      railties (>= 3.1.0)
-      turbolinks
     json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -323,7 +320,6 @@ DEPENDENCIES
   factory_girl_rails
   jbuilder (~> 2.5)
   jquery-rails
-  jquery-turbolinks
   letter_opener
   mailgun_rails
   momentjs-rails (>= 2.9.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery.turbolinks
 //= require jquery_ujs
 //= require turbolinks
 //= require moment

--- a/app/assets/javascripts/budgets.coffee
+++ b/app/assets/javascripts/budgets.coffee
@@ -12,6 +12,6 @@ calculateTotals = (month) ->
 $(document).on "format.money", "table.budgets input.money", ->
   calculateTotals $(@)
 
-$ ->
+$(document).on "turbolinks:load", ->
   $("table.budgets tbody tr:first-of-type input.money").each (index, item) ->
    calculateTotals item

--- a/app/assets/javascripts/select2-init.coffee
+++ b/app/assets/javascripts/select2-init.coffee
@@ -1,2 +1,2 @@
-$ ->
+$(document).on "turbolinks:load", ->
   $("select[multiple='multiple']").select2(theme: "bootstrap")


### PR DESCRIPTION
I was running into pages that did not have the select2 initialization
done, and thought that it was worth it for us to just start using
turbolinks properly.