### PR TITLE
Issue 281 make payee field non editable

### DIFF
--- a/app/assets/javascripts/components/GrantControls.jsx
+++ b/app/assets/javascripts/components/GrantControls.jsx
@@ -12,8 +12,7 @@ class GrantControls extends React.Component {
         grant_amount: $form.find("#gcf-grantAmount").val()
       },
       payee: {
-        check_number: $form.find("#gcf-checkNumber").val(),
-        name: $form.find("#gcf-payee").val()
+        check_number: $form.find("#gcf-checkNumber").val()
       }
     };
     $.ajax(`/grants/${this.props.grant.id}/update_controls`, {

--- a/app/assets/javascripts/components/GrantControlsForm.jsx
+++ b/app/assets/javascripts/components/GrantControlsForm.jsx
@@ -29,8 +29,8 @@ let GrantControlsForm = (props) => (
 
     <div className="form-group">
       <label className="control-label" htmlFor="gcf-payee">Payee</label>
-      <div className="form-control-static" id="gcf-payee">
-        {props.payee.name}
+      <div className={props.payee.name == null ? 'form-control-static text-italic' : 'form-control-static'} id="gcf-payee">
+        {props.payee.name != null ? props.payee.name : 'Unspecified'}
       </div>
     </div>
 

--- a/app/assets/javascripts/components/GrantControlsForm.jsx
+++ b/app/assets/javascripts/components/GrantControlsForm.jsx
@@ -29,8 +29,9 @@ let GrantControlsForm = (props) => (
 
     <div className="form-group">
       <label className="control-label" htmlFor="gcf-payee">Payee</label>
-      <input className="form-control" id="gcf-payee" name="number" type="text"
-             defaultValue={props.payee.name} />
+      <div className="form-control-static" id="gcf-payee">
+        {props.payee.name}
+      </div>
     </div>
 
     <div className="form-group hidden">

--- a/app/assets/stylesheets/grants.scss
+++ b/app/assets/stylesheets/grants.scss
@@ -8,3 +8,7 @@
   border-radius: 0px;
   padding: 12px 8px;
 }
+
+.text-italic {
+  font-style: italic;
+}

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -98,7 +98,7 @@ class GrantsController < ApplicationController
   end
 
   def grant_payee_params
-    params.require(:payee).permit(:name, :check_number)
+    params.require(:payee).permit(:check_number)
   end
 
   def people_attributes


### PR DESCRIPTION
Fixes #281 .

When it's not specified, it looks like this:
![image](https://cloud.githubusercontent.com/assets/444693/22621222/1a629342-eae4-11e6-8fae-79920fe928ce.png)

When it is specified, it looks like this:
![image](https://cloud.githubusercontent.com/assets/444693/22621225/2e1cd9d8-eae4-11e6-8ce5-282a58bd6ddb.png)
